### PR TITLE
allow to edit saturation curve

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,6 +491,46 @@ impl SaturationCurve {
             ydat_unc,
         })
     }
+    
+    pub fn get_xdat(&self) -> String {
+        self.xdat
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>()
+            .join(", ")
+    }
+    
+    pub fn get_xdat_unc(&self) -> String {
+        if let Some(xdat_unc) = &self.xdat_unc {
+            xdat_unc
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<Vec<String>>()
+                .join(", ")
+        } else {
+            String::new()
+        }
+    }
+    
+    pub fn get_ydat(&self) -> String {
+        self.ydat
+            .iter()
+            .map(|y| y.to_string())
+            .collect::<Vec<String>>()
+            .join(", ")
+    }
+    
+    pub fn get_ydat_unc(&self) -> String {
+        if let Some(ydat_unc) = &self.ydat_unc {
+            ydat_unc
+                .iter()
+                .map(|y| y.to_string())
+                .collect::<Vec<String>>()
+                .join(", ")
+        } else {
+            String::new()
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,7 +491,7 @@ impl SaturationCurve {
             ydat_unc,
         })
     }
-    
+
     pub fn get_xdat(&self) -> String {
         self.xdat
             .iter()
@@ -499,7 +499,7 @@ impl SaturationCurve {
             .collect::<Vec<String>>()
             .join(", ")
     }
-    
+
     pub fn get_xdat_unc(&self) -> String {
         if let Some(xdat_unc) = &self.xdat_unc {
             xdat_unc
@@ -511,7 +511,7 @@ impl SaturationCurve {
             String::new()
         }
     }
-    
+
     pub fn get_ydat(&self) -> String {
         self.ydat
             .iter()
@@ -519,7 +519,7 @@ impl SaturationCurve {
             .collect::<Vec<String>>()
             .join(", ")
     }
-    
+
     pub fn get_ydat_unc(&self) -> String {
         if let Some(ydat_unc) = &self.ydat_unc {
             ydat_unc


### PR DESCRIPTION
If a saturation curve with the same title as one before is added, the existing one will be overwritten.
This allows to add an edit feature button: This button simply loads the existing data from one curve into the fields.

Closes #1
