### PR TITLE
Fix urlencoding and linebreak formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2425,6 +2425,7 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
+ "regex",
  "rfd",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,6 +2430,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "urlencoding",
  "wasm-bindgen-futures",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { version = "1.0.116", features = ["std"] }
 rfd = "0.14.1"
 futures = "0.3.30"
 wasm-bindgen-futures = "0.4.42"
+urlencoding = "2.1.3"
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rfd = "0.14.1"
 futures = "0.3.30"
 wasm-bindgen-futures = "0.4.42"
 urlencoding = "2.1.3"
+regex = "1.10.5"
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,7 +661,7 @@ fn create_json_output(app_entries: &TemplateApp) -> Result<String, String> {
 
     // create the json file
     let mut json_out = json!({
-        "notes": app_entries.notes,
+        "notes": replace_linebreak(&app_entries.notes),
         "rims_scheme": {
             "scheme": {
                 "element": format!("{:?}", app_entries.scheme_element),
@@ -702,7 +702,7 @@ fn create_json_output(app_entries: &TemplateApp) -> Result<String, String> {
 
         let mut json_tmp = json!({
             "title": val.title,
-            "notes": val.notes,
+            "notes": replace_linebreak(&val.notes),
             "unit": sat_unit_json,
             "fit": val.fit,
             "data": {
@@ -943,6 +943,13 @@ fn is_doi(inp: &str) -> bool {
     inp.chars().filter(|c| *c == '/').count() == 1
 }
 
+/// Replace linebreaks with two spaces and a linebreak.
+/// This is used to format for proper markdown handling.
+fn replace_linebreak(inp: &str) -> String {
+    let re = regex::Regex::new(r" *\r?\n").unwrap();
+    re.replace_all(inp, "  \n").to_string()
+}
+
 /// Strip $ signs from beginning and end of a &str.
 /// This is used to remove LaTeX math mode from strings.
 fn strip_latex_dollars(inp: &str) -> &str {
@@ -991,6 +998,20 @@ fn test_is_doi() {
     assert!(is_doi(doi_good));
     let doi_bad = "https://doi.org/10.500/123456789";
     assert!(!is_doi(doi_bad));
+}
+
+#[test]
+fn test_replace_linebreak() {
+    assert_eq!(replace_linebreak("asdf\nbsdf"), "asdf  \nbsdf");
+    assert_eq!(replace_linebreak("asdf  \nbsdf"), "asdf  \nbsdf");
+    assert_eq!(replace_linebreak("asdf \nbsdf"), "asdf  \nbsdf");
+    assert_eq!(replace_linebreak("asdf       \nbsdf"), "asdf  \nbsdf");
+    assert_eq!(replace_linebreak(""), "");
+    assert_eq!(replace_linebreak("asdf"), "asdf");
+    assert_eq!(replace_linebreak("\n"), "  \n");
+    assert_eq!(replace_linebreak("asdf\nbsdf\ncsdf      \n"), "asdf  \nbsdf  \ncsdf  \n");
+    assert_eq!(replace_linebreak("asdf\n\n"), "asdf  \n  \n");
+    assert_eq!(replace_linebreak("asdf\r\nbsdf\ncsdf      \r\n"), "asdf  \nbsdf  \ncsdf  \n");
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ use std::str::FromStr;
 use serde_json::{json, ser::to_string_pretty, Value};
 use strum_macros::EnumIter;
 
+use urlencoding::encode;
+
 mod app;
 
 pub use app::TemplateApp;
@@ -637,7 +639,9 @@ fn create_gh_issue(body: &str, element: &Elements) -> String {
 
     format!(
         "https://github.com/RIMS-Code/rims-code.github.io/issues/new?labels={}&title={}&body={}",
-        label, title, body
+        label,
+        encode(&title),
+        encode(body)
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1009,9 +1009,15 @@ fn test_replace_linebreak() {
     assert_eq!(replace_linebreak(""), "");
     assert_eq!(replace_linebreak("asdf"), "asdf");
     assert_eq!(replace_linebreak("\n"), "  \n");
-    assert_eq!(replace_linebreak("asdf\nbsdf\ncsdf      \n"), "asdf  \nbsdf  \ncsdf  \n");
+    assert_eq!(
+        replace_linebreak("asdf\nbsdf\ncsdf      \n"),
+        "asdf  \nbsdf  \ncsdf  \n"
+    );
     assert_eq!(replace_linebreak("asdf\n\n"), "asdf  \n  \n");
-    assert_eq!(replace_linebreak("asdf\r\nbsdf\ncsdf      \r\n"), "asdf  \nbsdf  \ncsdf  \n");
+    assert_eq!(
+        replace_linebreak("asdf\r\nbsdf\ncsdf      \r\n"),
+        "asdf  \nbsdf  \ncsdf  \n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
- fix urlencoding bug. Now the whole text in json is encoded when sent via URL, so special symobls, etc., work.
- add replacement regex for line breaks to make them markdown compatible
